### PR TITLE
Carter Whitaker's UI Challenge

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ function App() {
   const [geotabInfo, setGeotabInfo] = useState<Tag[]>([]);
   const [selectedSiteId, setSelectedSiteId] = useState<string>('');
   const [searchTerm, setSearchTerm] = useState('');
+  const [isLeashedChecked, setIsLeashedChecked] = useState(true);
 
   // Load tag data
   const loadTags = useCallback(async () => {
@@ -126,7 +127,7 @@ function App() {
       }
       
       // Check leashed SuperTag name
-      if (asset.leashedToSuperTag && asset.leashedToSuperTag.toLowerCase().includes(lowercaseSearchTerm)) {
+      if (asset.leashedToSuperTag && asset.leashedToSuperTag.toLowerCase().includes(lowercaseSearchTerm) && isLeashedChecked) {
         return true;
       }
 
@@ -137,7 +138,7 @@ function App() {
       
       return false;
     });
-  }, [processedMarkers, searchTerm]);
+  }, [processedMarkers, searchTerm, isLeashedChecked]);
 
   const handleLogin = () => {
     setAuthenticated(true);
@@ -173,6 +174,8 @@ function App() {
                 <AssetTrackersPage
                   assets={filteredAssets}
                   searchTerm={searchTerm}
+                  isLeashedChecked={isLeashedChecked}
+                  onLeashedChange={setIsLeashedChecked}
                   onSearchChange={setSearchTerm}
                 />
               } 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -90,7 +90,7 @@ export function Header({
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5" />
                 <input
                   type="search"
-                  placeholder="Search assets..."
+                  placeholder="Name, MAC Addr, or SN"
                   value={searchTerm}
                   onChange={(e) => onSearchChange(e.target.value)}
                   className="pl-10 pr-4 py-2 border border-gray-200 rounded-lg w-64 focus:outline-none focus:ring-2 focus:ring-[#87B812]"

--- a/src/pages/AssetTrackersPage.tsx
+++ b/src/pages/AssetTrackersPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { Map } from '../components/Map';
 import { AssetList } from '../components/AssetList';
 import { AssetDetailOverlay } from '../components/AssetDetailOverlay';
@@ -43,6 +43,12 @@ export function AssetTrackersPage({
     zoom: selectedAsset ? 15 : 13
   };
 
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  function focusSearchBar() {
+    inputRef.current?.focus()
+  }
+
   return (
     <main className="h-[calc(100vh-153px)] relative">
       {/* Desktop Layout */}
@@ -51,16 +57,19 @@ export function AssetTrackersPage({
         <div className="w-2/10 bg-white border-r border-gray-200">
           <div className="p-4 border-b border-gray-200">
             <div className="relative">
-              <div className="flex border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#87B812]"
+              <div className="flex border border-gray-200 rounded-lg focus-within:outline-none focus-within:ring-2 focus-within:ring-[#87B812] items-center"
                    tabIndex={0}>
                 <input
+                  ref={inputRef}
                   type="search"
-                  placeholder="i.e. 'Car' 'F8:FC:C8:E4:0A:0B' 'L62721AE9B2A'"
+                  placeholder="Name, MAC Addr, or Serial #"
                   value={searchTerm}
                   onChange={(e) => onSearchChange(e.target.value)}
-                  className="w-full pl-4 pr-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#87B812]"
+                  className="w-11/12 pl-4 pr-4 py-2 rounded-lg focus:outline-none"
                 />
-                <Search className="w-5 h-5"/>
+                <div className="w-1/12 h-full pr-8 items-center"onClick={focusSearchBar}>
+                  <Search className="h-5 text-gray-700"/>
+                </div>
               </div>
             </div>
           </div>

--- a/src/pages/AssetTrackersPage.tsx
+++ b/src/pages/AssetTrackersPage.tsx
@@ -11,6 +11,8 @@ import { QrCode, ArrowLeft, Search } from 'lucide-react';
 interface AssetTrackersPageProps {
   assets: ProcessedMarker[];
   searchTerm: string;
+  isLeashedChecked: boolean;
+  onLeashedChange: (isChecked: boolean) => void;
   onSearchChange: (term: string) => void;
 }
 
@@ -19,14 +21,17 @@ type AssetViewType = 'all' | 'supertags' | 'sensors';
 export function AssetTrackersPage({
   assets,
   searchTerm,
+  isLeashedChecked,
+  onLeashedChange,
   onSearchChange
 }: AssetTrackersPageProps) {
   const [selectedAsset, setSelectedAsset] = useState<ProcessedMarker | null>(null);
   const [assetViewType, setAssetViewType] = useState<AssetViewType>(() => 
     (localStorage.getItem('assetViewType') as AssetViewType) || 'all'
   );
-  const [showQRScanner, setShowQRScanner] = useState(false);
+  const [showQRScanner, setShowQRScanner]       = useState(false);
   const [isDetailExpanded, setIsDetailExpanded] = useState(true);
+  const inputRef                                = useRef<HTMLInputElement>(null)
 
   const handleAssetSelect = (asset: ProcessedMarker | null) => {
     setSelectedAsset(asset);
@@ -42,8 +47,6 @@ export function AssetTrackersPage({
     center: selectedAsset ? selectedAsset.position : assets[0]?.position ?? [39.8283459, -98.5820546],
     zoom: selectedAsset ? 15 : 13
   };
-
-  const inputRef = useRef<HTMLInputElement>(null)
 
   function focusSearchBar() {
     inputRef.current?.focus()
@@ -67,10 +70,23 @@ export function AssetTrackersPage({
                   onChange={(e) => onSearchChange(e.target.value)}
                   className="w-11/12 pl-4 pr-4 py-2 rounded-lg focus:outline-none"
                 />
-                <div className="w-1/12 h-full pr-8 items-center"onClick={focusSearchBar}>
+                <div className="w-1/12 h-full pr-8 items-center" onClick={focusSearchBar}>
                   <Search className="h-5 text-gray-700"/>
                 </div>
               </div>
+              <label className="flex justify-between items-center pt-2 pl-1 cursor-pointer">
+                <span className="pr-2 text-gray-700">Include Connected Assets</span>
+                <div className="relative">
+                  <input
+                    type="checkbox"
+                    checked={isLeashedChecked}
+                    onChange={(e) => onLeashedChange(e.target.checked)}
+                    className="sr-only peer"
+                  />
+                  <div className="block h-6 w-10 rounded-full bg-[#E5E7EB] peer-checked:bg-[#87B812] transition"></div>
+                  <div className="dot absolute left-1 top-1 h-4 w-4 rounded-full bg-white peer-checked:left-5 transition"></div>
+                </div>                  
+              </label>
             </div>
           </div>
           <div className="overflow-y-auto h-[calc(100%-75px)]">
@@ -111,7 +127,7 @@ export function AssetTrackersPage({
               <div className="relative">
                 <input
                   type="search"
-                  placeholder="Search assets..."
+                  placeholder="Search by: Name, MAC Addr, or SN"
                   value={searchTerm}
                   onChange={(e) => onSearchChange(e.target.value)}
                   className="w-full pl-4 pr-12 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#87B812]"
@@ -124,6 +140,19 @@ export function AssetTrackersPage({
                   <QrCode className="w-5 h-5 text-gray-400 hover:text-[#87B812]" />
                 </button>
               </div>
+              <label className="flex justify-between items-center pt-2 pl-1 cursor-pointer">
+                <span className="pr-2 text-gray-700">Include Connected Assets</span>
+                <div className="relative">
+                  <input
+                    type="checkbox"
+                    checked={isLeashedChecked}
+                    onChange={(e) => onLeashedChange(e.target.checked)}
+                    className="sr-only peer"
+                  />
+                  <div className="block h-6 w-10 rounded-full bg-[#E5E7EB] peer-checked:bg-[#87B812] transition"></div>
+                  <div className="dot absolute left-1 top-1 h-4 w-4 rounded-full bg-white peer-checked:left-5 transition"></div>
+                </div>                  
+              </label>
             </div>
 
             <div className="flex-1 overflow-y-auto">

--- a/src/pages/AssetTrackersPage.tsx
+++ b/src/pages/AssetTrackersPage.tsx
@@ -6,7 +6,7 @@ import { Dashboard } from '../components/Dashboard';
 import { QRScanner } from '../components/QRScanner';
 import { SuperTagConfiguration } from '../components/SuperTagConfiguration';
 import { ProcessedMarker } from '../types/assets';
-import { QrCode, ArrowLeft } from 'lucide-react';
+import { QrCode, ArrowLeft, Search } from 'lucide-react';
 
 interface AssetTrackersPageProps {
   assets: ProcessedMarker[];
@@ -51,13 +51,17 @@ export function AssetTrackersPage({
         <div className="w-2/10 bg-white border-r border-gray-200">
           <div className="p-4 border-b border-gray-200">
             <div className="relative">
-              <input
-                type="search"
-                placeholder="Search assets..."
-                value={searchTerm}
-                onChange={(e) => onSearchChange(e.target.value)}
-                className="w-full pl-4 pr-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#87B812]"
-              />
+              <div className="flex border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#87B812]"
+                   tabIndex={0}>
+                <input
+                  type="search"
+                  placeholder="i.e. 'Car' 'F8:FC:C8:E4:0A:0B' 'L62721AE9B2A'"
+                  value={searchTerm}
+                  onChange={(e) => onSearchChange(e.target.value)}
+                  className="w-full pl-4 pr-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#87B812]"
+                />
+                <Search className="w-5 h-5"/>
+              </div>
             </div>
           </div>
           <div className="overflow-y-auto h-[calc(100%-75px)]">


### PR DESCRIPTION
This is my work done to complete the three assignments given to me by Dr. Pilat as part of my interview process.

Challenge 1: Show the user the three asset attributes you can search by.
Changes Made: Changed the placeholder text to indicate the searchable asset attributes and added a search icon to the search bar. This was done in the main search, the mobile search, and the hidden search in the header.
Reasoning: I added the search icon because, after I changed the placeholder text to no longer include the word "search," it looked less like a search bar. So, the icon added additional clarification. The placeholder text is abbreviations of the searchable asset attributes to make sure all the text is visible instead of overflowing. 

Challenge 2: Remove the extra "View Location History" button at the bottom of the main page content.
Changes Made: None
Reasoning: I was unable to find the button referred to in the video. I assume it was removed already by someone else. I only found three of those buttons:
	1) In the "Asset Identifiers" box, displayed when an asset is selected
	2) Under the map/above the "Asset Identifiers" box, that is displayed in the mobile UI
	3) A blue version of the button in the Map component

Challenge 3 (bonus): Allow the user to choose whether or not the search results will include connected assets.
Changes Made: I created a toggle slider under the search bar. When on, it includes the connected assets, and otherwise does not.
Reasoning: It took a little bit to find, but, in the App component, the assets are filtered based on the search. I decided to make the change in that filter function because all I had to do was pass the toggle slider value up, similar to how the search term is passed. I assumed that the "isLeashedChecked" prop was what determined the connected assets, so I included a check there. If the toggle slider is on, it includes the leashed asset and does not when the slider is off. 
*Note: When searching by a word, the results include assets with the search term in the name, and also assets who's type includes the search term. For example, searching "temp" includes an asset called "Temp Gateway" and any other assets that are Temperature Tags. I did not change this, so those assets remain even when connected assets are not included in the search results.  
